### PR TITLE
fix(scripts): correct multi-line string syntax in PowerShell script

### DIFF
--- a/scripts/create-fully-portable-package.ps1
+++ b/scripts/create-fully-portable-package.ps1
@@ -574,10 +574,7 @@ check-dependencies.bat
 
 ### Manual Dependency Installation
 $(if ($OfflineMode) {
-"If dependencies are missing:"
-"```cmd"
-"dependencies\install-dependencies-offline.bat"
-"```"
+"If dependencies are missing:`n```cmd`ndependencies\install-dependencies-offline.bat`n```"
 } else {
 "Ensure internet access for first run, or obtain offline dependency package"
 })


### PR DESCRIPTION
## Summary
- Fixed PowerShell parser error where multiple string literals in conditional expression were causing syntax errors
- Consolidated multi-line output into single string with embedded newline characters (`n) for proper parsing

## Problem
The script was failing with:
```
Unexpected token 'Ensure' in expression or statement.
The string is missing the terminator: ".
Missing closing '}' in statement block or type definition.
```

## Solution
Changed from multiple string literals:
```powershell
$(if ($OfflineMode) {
"If dependencies are missing:"
"```cmd"
"dependencies\install-dependencies-offline.bat"
"```"
} else {
```

To single string with newlines:
```powershell
$(if ($OfflineMode) {
"If dependencies are missing:`n```cmd`ndependencies\install-dependencies-offline.bat`n```"
} else {
```

## Test plan
- [ ] Run `.\create-fully-portable-package.ps1` without syntax errors
- [ ] Verify the generated README.txt displays the manual dependency installation section correctly
- [ ] Confirm markdown formatting is preserved in the output

🤖 Generated with [Claude Code](https://claude.ai/code)