### PR TITLE
Fix build script markdown and add PowerShell syntax test script

### DIFF
--- a/scripts/create-fully-portable-package.ps1
+++ b/scripts/create-fully-portable-package.ps1
@@ -574,7 +574,10 @@ check-dependencies.bat
 
 ### Manual Dependency Installation
 $(if ($OfflineMode) {
-"If dependencies are missing:`n```cmd`ndependencies\install-dependencies-offline.bat`n```"
+"If dependencies are missing:
+````cmd
+dependencies\install-dependencies-offline.bat
+````"
 } else {
 "Ensure internet access for first run, or obtain offline dependency package"
 })
@@ -597,7 +600,7 @@ $(if ($OfflineMode) {
 - Corporate Support: Available
 
 ---
-**Generated**: `$(Get-Date -Format "yyyy-MM-dd HH:mm:ss")
+**Generated**: $(Get-Date -Format "yyyy-MM-dd HH:mm:ss")
 **Platform**: $Platform  
 **Python**: $PythonVersion
 **Offline Mode**: $(if ($OfflineMode) { "Enabled" } else { "First-run setup required" })

--- a/scripts/test-powershell-syntax.ps1
+++ b/scripts/test-powershell-syntax.ps1
@@ -1,0 +1,46 @@
+#!/usr/bin/env pwsh
+# Test PowerShell script syntax
+
+$scripts = @(
+    "create-fully-portable-package.ps1",
+    "create-portable-package.ps1", 
+    "corporate-setup-windows.ps1"
+)
+
+$hasErrors = $false
+
+foreach ($script in $scripts) {
+    Write-Host "Testing $script..." -ForegroundColor Yellow
+    
+    $scriptPath = Join-Path $PSScriptRoot $script
+    
+    if (Test-Path $scriptPath) {
+        $errors = $null
+        $tokens = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+            $scriptPath,
+            [ref]$tokens,
+            [ref]$errors
+        )
+        
+        if ($errors.Count -eq 0) {
+            Write-Host "  [OK] No syntax errors found" -ForegroundColor Green
+        } else {
+            Write-Host "  [ERROR] Found $($errors.Count) syntax error(s):" -ForegroundColor Red
+            foreach ($error in $errors) {
+                Write-Host "    Line $($error.Extent.StartLineNumber): $($error.Message)" -ForegroundColor Red
+            }
+            $hasErrors = $true
+        }
+    } else {
+        Write-Host "  [SKIP] File not found" -ForegroundColor Yellow
+    }
+}
+
+if ($hasErrors) {
+    Write-Host "`n[FAILED] Some scripts have syntax errors" -ForegroundColor Red
+    exit 1
+} else {
+    Write-Host "`n[SUCCESS] All scripts passed syntax check" -ForegroundColor Green
+    exit 0
+}


### PR DESCRIPTION
## Summary
- Corrects markdown formatting in `create-fully-portable-package.ps1` script
- Adds a new PowerShell script `test-powershell-syntax.ps1` to validate syntax of key PowerShell scripts

## Changes

### Script Fixes
- Fixed incorrect markdown code block delimiters in `create-fully-portable-package.ps1` to properly render offline dependency instructions
- Corrected date generation line to remove extraneous backticks for proper output formatting

### New Script Addition
- Added `test-powershell-syntax.ps1` script to:
  - Test syntax of important PowerShell scripts (`create-fully-portable-package.ps1`, `create-portable-package.ps1`, `corporate-setup-windows.ps1`)
  - Report any syntax errors with line numbers and messages
  - Exit with failure code if errors are found, success otherwise

## Test plan
- Run `test-powershell-syntax.ps1` to verify no syntax errors in the listed scripts
- Confirm corrected markdown renders properly in generated output of `create-fully-portable-package.ps1`
- Validate build scripts run without syntax or formatting issues after changes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/23b53960-0af1-45a3-a4ae-255f6d66db87