### PR TITLE
Fix string interpolation in warning messages in portable package script

### DIFF
--- a/scripts/create-fully-portable-package.ps1
+++ b/scripts/create-fully-portable-package.ps1
@@ -740,7 +740,7 @@ if os.path.exists(site_packages):
                                 }
                                 [System.IO.File]::WriteAllText($pth, $pthContent, $utf8NoBom)
                             } catch {
-                                Write-Host "[WARN] Could not recreate $pth: $($_.Exception.Message)" -ForegroundColor Yellow
+                                Write-Host "[WARN] Could not recreate ${pth}: $($_.Exception.Message)" -ForegroundColor Yellow
                             }
                         }
                         Write-Host "[OK] Recreated _pth files after pip reinstall" -ForegroundColor Green

--- a/scripts/create-fully-portable-package.ps1.backup
+++ b/scripts/create-fully-portable-package.ps1.backup
@@ -304,7 +304,7 @@ if (-not $pipInstallSuccess) {
                             }
                             [System.IO.File]::WriteAllText($pth, $pthContent, $utf8NoBom)
                         } catch {
-                            Write-Host "[WARN] Could not recreate $pth: $($_.Exception.Message)" -ForegroundColor Yellow
+                            Write-Host "[WARN] Could not recreate ${pth}: $($_.Exception.Message)" -ForegroundColor Yellow
                         }
                     }
                     Write-Host "[OK] Recreated _pth files after pip reinstall" -ForegroundColor Green


### PR DESCRIPTION
## Summary
- Corrects string interpolation syntax in warning messages within the `create-fully-portable-package.ps1` script
- Ensures variable `${pth}` is properly expanded in warning output for better clarity

## Changes

### Script Fixes
- Updated warning message lines in both `create-fully-portable-package.ps1` and its backup file to use `${pth}` instead of `$pth` for string interpolation
- This change improves the readability and correctness of warning logs when file recreation fails

## Test plan
- [x] Run the portable package creation script on Windows 10
- [x] Verify that warning messages correctly display the file path when errors occur
- [x] Confirm no other script functionality is affected by this change

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3ab9b251-9209-401c-a0ca-b803af74f147