### PR TITLE
Fix syntax errors in Windows portable workflow script

### DIFF
--- a/.github/workflows/windows-portable.yml
+++ b/.github/workflows/windows-portable.yml
@@ -172,7 +172,7 @@ jobs:
               
               # Select appropriate URL for architecture
               $downloadUrl = $serverInfo.url
-              if (${{ matrix.arch }} -eq "arm64" -and $serverInfo.ContainsKey("url_arm64")) {
+              if ("${{ matrix.arch }}" -eq "arm64" -and $serverInfo.ContainsKey("url_arm64")) {
                 $downloadUrl = $serverInfo.url_arm64
               }
               
@@ -241,7 +241,7 @@ jobs:
               
               # Select appropriate URL for architecture  
               $downloadUrl = $serverInfo.url
-              if (${{ matrix.arch }} -eq "arm64" -and $serverInfo.ContainsKey("url_arm64")) {
+              if ("${{ matrix.arch }}" -eq "arm64" -and $serverInfo.ContainsKey("url_arm64")) {
                 $downloadUrl = $serverInfo.url_arm64
               }
               
@@ -304,7 +304,7 @@ jobs:
           )
           
           # Add debug flags if requested
-          if (${{ inputs.pyinstaller_debug || 'false' }}) {
+          if ("${{ inputs.pyinstaller_debug || 'false' }}" -eq "true") {
             $pyinstallerArgs += @("--debug", "all", "--log-level", "DEBUG")
           }
           


### PR DESCRIPTION
## Summary
- Corrects syntax errors in the GitHub Actions workflow for Windows portable builds
- Fixes conditional expressions to properly evaluate architecture and debug input values

## Changes

### Workflow Script Fixes
- Updated conditional checks to use string comparison for `matrix.arch` instead of incorrect syntax
- Fixed debug flag condition to correctly compare string values for enabling PyInstaller debug mode

## Test plan
- [ ] Verify that the workflow correctly selects the download URL based on architecture
- [ ] Confirm that debug flags are added when `pyinstaller_debug` input is set to true
- [ ] Run the Windows portable build workflow to ensure no syntax errors occur

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/87e0d148-cb71-463d-8845-b0c2c67d29ca