### PR TITLE
Add Windows portable build workflow

### DIFF
--- a/.github/workflows/build-windows-portable.yml
+++ b/.github/workflows/build-windows-portable.yml
@@ -1,0 +1,326 @@
+name: Build Windows Portable
+
+on:
+  workflow_dispatch:
+    inputs:
+      bundle_tier:
+        description: 'Bundle tier'
+        required: true
+        default: 'essential'
+        type: choice
+        options:
+          - minimal
+          - essential
+          - complete
+          - full
+      architecture:
+        description: 'Architecture'
+        required: true
+        default: 'x64'
+        type: choice
+        options:
+          - x64
+          - arm64
+
+env:
+  PYTHON_VERSION: "3.11"
+
+jobs:
+  build:
+    name: Build Windows Portable
+    runs-on: windows-latest
+    timeout-minutes: 60
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          architecture: ${{ inputs.architecture }}
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .venv
+            ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ inputs.architecture }}-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+          restore-keys: |
+            uv-${{ runner.os }}-${{ inputs.architecture }}-
+            uv-${{ runner.os }}-
+
+      - name: Install dependencies
+        shell: powershell
+        run: |
+          uv venv --python ${{ env.PYTHON_VERSION }}
+          uv pip install -e ".[dev]"
+          uv pip install pyinstaller==6.11.1
+
+      - name: Download language servers (Essential)
+        if: inputs.bundle_tier != 'minimal'
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          Write-Host "Downloading essential language servers..."
+          
+          New-Item -ItemType Directory -Force -Path "build/language_servers"
+          
+          # Download essential servers (simplified)
+          $servers = @{
+            "pyright" = "https://registry.npmjs.org/pyright/-/pyright-1.1.405.tgz"
+            "typescript" = "https://registry.npmjs.org/typescript-language-server/-/typescript-language-server-4.4.0.tgz"
+          }
+          
+          if ("${{ inputs.architecture }}" -eq "x64") {
+            $servers["rust-analyzer"] = "https://github.com/rust-lang/rust-analyzer/releases/download/2025-08-25/rust-analyzer-x86_64-pc-windows-msvc.zip"
+            $servers["gopls"] = "https://github.com/golang/tools/releases/download/gopls/v0.20.0/gopls-windows-amd64.zip"
+          } else {
+            $servers["rust-analyzer"] = "https://github.com/rust-lang/rust-analyzer/releases/download/2025-08-25/rust-analyzer-aarch64-pc-windows-msvc.zip"
+            $servers["gopls"] = "https://github.com/golang/tools/releases/download/gopls/v0.20.0/gopls-windows-arm64.zip"
+          }
+          
+          foreach ($name in $servers.Keys) {
+            $url = $servers[$name]
+            $dir = "build/language_servers/$name"
+            
+            Write-Host "Downloading $name..."
+            New-Item -ItemType Directory -Force -Path $dir | Out-Null
+            
+            $tempFile = [System.IO.Path]::GetTempFileName()
+            
+            try {
+              Invoke-WebRequest -Uri $url -OutFile $tempFile -UseBasicParsing
+              
+              if ($url -like "*.zip") {
+                Expand-Archive -Path $tempFile -DestinationPath $dir -Force
+              } elseif ($url -like "*.tgz" -or $url -like "*.tar.gz") {
+                tar -xzf $tempFile -C $dir --strip-components=1
+              }
+              
+              Write-Host "✓ Downloaded $name"
+            } catch {
+              Write-Warning "Failed to download $name: $_"
+            } finally {
+              Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
+            }
+          }
+
+      - name: Download additional servers (Complete/Full)
+        if: inputs.bundle_tier == 'complete' || inputs.bundle_tier == 'full'
+        shell: powershell
+        run: |
+          Write-Host "Downloading additional language servers for ${{ inputs.bundle_tier }} tier..."
+          
+          $servers = @{
+            "java" = "https://download.eclipse.org/jdtls/milestones/1.50.0/jdt-language-server-1.50.0-202509041608.tar.gz"
+            "lua" = "https://github.com/LuaLS/lua-language-server/releases/download/3.15.0/lua-language-server-3.15.0-win32-x64.zip"
+            "bash" = "https://registry.npmjs.org/bash-language-server/-/bash-language-server-5.6.0.tgz"
+          }
+          
+          if ("${{ inputs.architecture }}" -eq "x64") {
+            $servers["omnisharp"] = "https://roslynomnisharp.blob.core.windows.net/releases/1.39.14/omnisharp-win-x64-1.39.14.zip"
+          } else {
+            $servers["omnisharp"] = "https://roslynomnisharp.blob.core.windows.net/releases/1.39.14/omnisharp-win-arm64-1.39.14.zip"
+          }
+          
+          foreach ($name in $servers.Keys) {
+            $url = $servers[$name]
+            $dir = "build/language_servers/$name"
+            
+            if (!(Test-Path $dir)) {
+              Write-Host "Downloading $name..."
+              New-Item -ItemType Directory -Force -Path $dir | Out-Null
+              
+              $tempFile = [System.IO.Path]::GetTempFileName()
+              
+              try {
+                Invoke-WebRequest -Uri $url -OutFile $tempFile -UseBasicParsing
+                
+                if ($url -like "*.zip") {
+                  Expand-Archive -Path $tempFile -DestinationPath $dir -Force
+                } elseif ($url -like "*.tgz" -or $url -like "*.tar.gz") {
+                  tar -xzf $tempFile -C $dir --strip-components=1
+                }
+                
+                Write-Host "✓ Downloaded $name"
+              } catch {
+                Write-Warning "Failed to download $name: $_"
+              } finally {
+                Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
+              }
+            }
+          }
+
+      - name: Run tests
+        shell: powershell
+        run: |
+          uv run poe format
+          uv run poe type-check
+
+      - name: Build with PyInstaller
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          
+          Write-Host "Building Serena portable executable..."
+          
+          $version = (Select-String -Path "pyproject.toml" -Pattern 'version = "([^"]+)"').Matches[0].Groups[1].Value
+          $outputName = "serena-${{ inputs.architecture }}-${{ inputs.bundle_tier }}-${version}"
+          
+          # Create a simple spec file
+          @"
+# -*- mode: python ; coding: utf-8 -*-
+import sys
+from pathlib import Path
+
+block_cipher = None
+
+# Find paths
+spec_dir = Path(r'$PWD').absolute()
+src_path = spec_dir / 'src'
+sys.path.insert(0, str(src_path))
+
+a = Analysis(
+    [str(src_path / 'serena' / 'cli.py')],
+    pathex=[str(src_path)],
+    binaries=[],
+    datas=[
+        (str(src_path / 'serena'), 'serena'),
+        (str(src_path / 'solidlsp'), 'solidlsp'),
+        (str(src_path / 'interprompt'), 'interprompt'),
+    ],
+    hiddenimports=[
+        'serena',
+        'serena.agent',
+        'serena.cli',
+        'serena.tools',
+        'solidlsp',
+        'solidlsp.ls',
+        'interprompt',
+        'mcp',
+        'anthropic',
+        'pydantic',
+        'yaml',
+        'jinja2',
+        'flask',
+        'click',
+        'rich',
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=['tkinter', 'matplotlib', 'PIL'],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+# Add language servers if they exist
+ls_dir = spec_dir / 'build' / 'language_servers'
+if ls_dir.exists():
+    a.datas.append((str(ls_dir), 'language_servers'))
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='$outputName',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+"@ | Out-File -FilePath "build.spec" -Encoding utf8
+          
+          # Run PyInstaller
+          uv run pyinstaller build.spec --clean --noconfirm
+          
+          if (Test-Path "dist/${outputName}.exe") {
+            $size = (Get-Item "dist/${outputName}.exe").Length / 1MB
+            Write-Host "✓ Built executable: ${outputName}.exe (${size:N2} MB)"
+            
+            # Test executable
+            & "dist/${outputName}.exe" --version
+          } else {
+            throw "Build failed - executable not found"
+          }
+
+      - name: Create distribution package
+        shell: powershell
+        run: |
+          $version = (Select-String -Path "pyproject.toml" -Pattern 'version = "([^"]+)"').Matches[0].Groups[1].Value
+          $outputName = "serena-${{ inputs.architecture }}-${{ inputs.bundle_tier }}-${version}"
+          
+          $bundleDir = "dist/bundle"
+          New-Item -ItemType Directory -Force -Path "$bundleDir/bin" | Out-Null
+          
+          # Copy executable
+          Copy-Item "dist/${outputName}.exe" "$bundleDir/bin/serena.exe"
+          
+          # Copy docs
+          if (Test-Path "README.md") { Copy-Item "README.md" "$bundleDir/" }
+          if (Test-Path "LICENSE") { Copy-Item "LICENSE" "$bundleDir/" }
+          
+          # Create installer script
+          @"
+@echo off
+echo Installing Serena...
+set INSTALL_DIR=%LOCALAPPDATA%\Serena
+if not exist "%INSTALL_DIR%" mkdir "%INSTALL_DIR%"
+copy /Y bin\serena.exe "%INSTALL_DIR%\serena.exe"
+echo Installation complete!
+echo Run 'serena --version' to verify.
+pause
+"@ | Out-File -FilePath "$bundleDir/install.bat" -Encoding ascii
+          
+          # Create ZIP
+          Compress-Archive -Path "$bundleDir/*" -DestinationPath "dist/${outputName}.zip" -CompressionLevel Optimal
+          
+          $zipSize = (Get-Item "dist/${outputName}.zip").Length / 1MB
+          Write-Host "✓ Created bundle: ${outputName}.zip (${zipSize:N2} MB)"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: serena-windows-${{ inputs.architecture }}-${{ inputs.bundle_tier }}
+          path: |
+            dist/*.exe
+            dist/*.zip
+          retention-days: 30
+
+      - name: Summary
+        shell: powershell
+        run: |
+          Write-Host "## Build Summary" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY
+          Write-Host "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          Write-Host "- **Architecture**: ${{ inputs.architecture }}" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          Write-Host "- **Bundle Tier**: ${{ inputs.bundle_tier }}" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          Write-Host "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          
+          Get-ChildItem dist/*.exe, dist/*.zip | ForEach-Object {
+            $size = $_.Length / 1MB
+            Write-Host "- **$($_.Name)**: ${size:N2} MB" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          }

--- a/.github/workflows/build-windows-portable.yml
+++ b/.github/workflows/build-windows-portable.yml
@@ -107,7 +107,7 @@ jobs:
                 tar -xzf $tempFile -C $dir --strip-components=1
               }
               
-              Write-Host "✓ Downloaded $name"
+              Write-Host "[OK] Downloaded $name"
             } catch {
               Write-Warning "Failed to download $name: $_"
             } finally {
@@ -152,7 +152,7 @@ jobs:
                   tar -xzf $tempFile -C $dir --strip-components=1
                 }
                 
-                Write-Host "✓ Downloaded $name"
+                Write-Host "[OK] Downloaded $name"
               } catch {
                 Write-Warning "Failed to download $name: $_"
               } finally {
@@ -260,7 +260,7 @@ exe = EXE(
           
           if (Test-Path "dist/${outputName}.exe") {
             $size = (Get-Item "dist/${outputName}.exe").Length / 1MB
-            Write-Host "✓ Built executable: ${outputName}.exe (${size:N2} MB)"
+            Write-Host "[OK] Built executable: ${outputName}.exe (${size:N2} MB)"
             
             # Test executable
             & "dist/${outputName}.exe" --version
@@ -300,7 +300,7 @@ pause
           Compress-Archive -Path "$bundleDir/*" -DestinationPath "dist/${outputName}.zip" -CompressionLevel Optimal
           
           $zipSize = (Get-Item "dist/${outputName}.zip").Length / 1MB
-          Write-Host "✓ Created bundle: ${outputName}.zip (${zipSize:N2} MB)"
+          Write-Host "[OK] Created bundle: ${outputName}.zip (${zipSize:N2} MB)"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-windows-portable.yml
+++ b/.github/workflows/test-windows-portable.yml
@@ -67,9 +67,9 @@ jobs:
               
               try {
                 $null = [System.Management.Automation.PSParser]::Tokenize((Get-Content $script -Raw), [ref]$null)
-                Write-Host "✓ $script syntax OK" -ForegroundColor Green
+                Write-Host "[OK] $script syntax OK" -ForegroundColor Green
               } catch {
-                Write-Host "✗ $script syntax error: $_" -ForegroundColor Red
+                Write-Host "[FAIL] $script syntax error: $_" -ForegroundColor Red
                 $errors += "$script : $_"
               }
             } else {
@@ -112,9 +112,9 @@ jobs:
                   }
                 }
                 
-                Write-Host "✓ $workflow structure OK" -ForegroundColor Green
+                Write-Host "[OK] $workflow structure OK" -ForegroundColor Green
               } catch {
-                Write-Host "✗ $workflow validation error: $_" -ForegroundColor Red
+                Write-Host "[FAIL] $workflow validation error: $_" -ForegroundColor Red
                 exit 1
               }
             }
@@ -172,13 +172,13 @@ jobs:
             try {
               $response = Invoke-WebRequest -Uri $url -Method Head -TimeoutSec 10 -UseBasicParsing
               if ($response.StatusCode -eq 200) {
-                Write-Host "✓ $url" -ForegroundColor Green
+                Write-Host "[OK] $url" -ForegroundColor Green
               } else {
-                Write-Host "✗ $url (Status: $($response.StatusCode))" -ForegroundColor Red
+                Write-Host "[FAIL] $url (Status: $($response.StatusCode))" -ForegroundColor Red
                 $failedUrls += "$url (Status: $($response.StatusCode))"
               }
             } catch {
-              Write-Host "✗ $url (Error: $($_.Exception.Message))" -ForegroundColor Red
+              Write-Host "[FAIL] $url (Error: $($_.Exception.Message))" -ForegroundColor Red
               $failedUrls += "$url (Error: $($_.Exception.Message))"
             }
           }
@@ -198,7 +198,7 @@ jobs:
           
           # Check if pyproject.toml exists and is valid
           if (Test-Path "pyproject.toml") {
-            Write-Host "✓ pyproject.toml found" -ForegroundColor Green
+            Write-Host "[OK] pyproject.toml found" -ForegroundColor Green
             
             $content = Get-Content "pyproject.toml" -Raw
             
@@ -206,16 +206,16 @@ jobs:
             $requiredFields = @("name", "version", "description")
             foreach ($field in $requiredFields) {
               if ($content -match "$field\s*=") {
-                Write-Host "✓ Found $field field" -ForegroundColor Green
+                Write-Host "[OK] Found $field field" -ForegroundColor Green
               } else {
-                Write-Host "✗ Missing $field field" -ForegroundColor Red
+                Write-Host "[FAIL] Missing $field field" -ForegroundColor Red
                 exit 1
               }
             }
             
             # Check for entry points or scripts
             if ($content -match "scripts" -or $content -match "entry-points") {
-              Write-Host "✓ Entry points/scripts configuration found" -ForegroundColor Green
+              Write-Host "[OK] Entry points/scripts configuration found" -ForegroundColor Green
             }
             
             # Look for main module files
@@ -223,19 +223,19 @@ jobs:
             $foundModule = $false
             foreach ($module in $mainModules) {
               if (Test-Path $module) {
-                Write-Host "✓ Found main module: $module" -ForegroundColor Green
+                Write-Host "[OK] Found main module: $module" -ForegroundColor Green
                 $foundModule = $true
                 break
               }
             }
             
             if (-not $foundModule) {
-              Write-Host "✗ No main module found in expected locations" -ForegroundColor Red
+              Write-Host "[FAIL] No main module found in expected locations" -ForegroundColor Red
               exit 1
             }
             
           } else {
-            Write-Host "✗ pyproject.toml not found" -ForegroundColor Red
+            Write-Host "[FAIL] pyproject.toml not found" -ForegroundColor Red
             exit 1
           }
 
@@ -278,7 +278,7 @@ jobs:
           
           $buildScript = "scripts/build-windows/build-portable.ps1"
           if (-not (Test-Path $buildScript)) {
-            Write-Host "✗ Build script not found: $buildScript" -ForegroundColor Red
+            Write-Host "[FAIL] Build script not found: $buildScript" -ForegroundColor Red
             exit 1
           }
           
@@ -286,13 +286,13 @@ jobs:
           try {
             # This should not fail - just tests parameter binding
             $null = & $buildScript -WhatIf -Tier ${{ matrix.tier }} -Architecture ${{ matrix.arch }} -SkipTests -SkipLanguageServers -Verbose:$false 2>$null
-            Write-Host "✓ Build script accepts parameters correctly" -ForegroundColor Green
+            Write-Host "[OK] Build script accepts parameters correctly" -ForegroundColor Green
           } catch {
             if ($_.Exception.Message -match "WhatIf") {
               # WhatIf not supported is OK, means parameters were accepted
-              Write-Host "✓ Build script parameters validated (WhatIf not supported)" -ForegroundColor Green
+              Write-Host "[OK] Build script parameters validated (WhatIf not supported)" -ForegroundColor Green
             } else {
-              Write-Host "✗ Build script parameter error: $_" -ForegroundColor Red
+              Write-Host "[FAIL] Build script parameter error: $_" -ForegroundColor Red
               exit 1
             }
           }
@@ -306,23 +306,23 @@ jobs:
             # Quick dependency sync test
             uv sync --dev --dry-run
             if ($LASTEXITCODE -eq 0) {
-              Write-Host "✓ Dependencies can be resolved" -ForegroundColor Green
+              Write-Host "[OK] Dependencies can be resolved" -ForegroundColor Green
             } else {
-              Write-Host "✗ Dependency resolution failed" -ForegroundColor Red
+              Write-Host "[FAIL] Dependency resolution failed" -ForegroundColor Red
               exit 1
             }
             
             # Test PyInstaller installation simulation
             uv add --dry-run pyinstaller
             if ($LASTEXITCODE -eq 0) {
-              Write-Host "✓ PyInstaller can be installed" -ForegroundColor Green
+              Write-Host "[OK] PyInstaller can be installed" -ForegroundColor Green
             } else {
-              Write-Host "✗ PyInstaller installation test failed" -ForegroundColor Red  
+              Write-Host "[FAIL] PyInstaller installation test failed" -ForegroundColor Red  
               exit 1
             }
             
           } catch {
-            Write-Host "✗ Dependency test failed: $_" -ForegroundColor Red
+            Write-Host "[FAIL] Dependency test failed: $_" -ForegroundColor Red
             exit 1
           }
 
@@ -336,18 +336,18 @@ jobs:
           uv pip install -e "."
           
           # Test basic imports
-          uv run python -c "import serena; print('✓ Serena imports successfully')"
+          uv run python -c "import serena; print('[OK] Serena imports successfully')"
           if ($LASTEXITCODE -ne 0) {
-            Write-Host "✗ Basic import test failed" -ForegroundColor Red
+            Write-Host "[FAIL] Basic import test failed" -ForegroundColor Red
             exit 1
           }
           
           # Test CLI help
           uv run python -m serena --help > nul 2>&1
           if ($LASTEXITCODE -eq 0) {
-            Write-Host "✓ CLI help works" -ForegroundColor Green
+            Write-Host "[OK] CLI help works" -ForegroundColor Green
           } else {
-            Write-Host "✗ CLI help failed" -ForegroundColor Red
+            Write-Host "[FAIL] CLI help failed" -ForegroundColor Red
             exit 1
           }
 
@@ -383,9 +383,9 @@ jobs:
           Write-Host "Running code formatting check..." -ForegroundColor Green
           uv run poe lint
           if ($LASTEXITCODE -eq 0) {
-            Write-Host "✓ Code formatting check passed" -ForegroundColor Green
+            Write-Host "[OK] Code formatting check passed" -ForegroundColor Green
           } else {
-            Write-Host "✗ Code formatting issues found" -ForegroundColor Red
+            Write-Host "[FAIL] Code formatting issues found" -ForegroundColor Red
             exit 1
           }
 
@@ -395,9 +395,9 @@ jobs:
           Write-Host "Running type checking..." -ForegroundColor Green
           uv run poe type-check
           if ($LASTEXITCODE -eq 0) {
-            Write-Host "✓ Type checking passed" -ForegroundColor Green
+            Write-Host "[OK] Type checking passed" -ForegroundColor Green
           } else {
-            Write-Host "✗ Type checking failed" -ForegroundColor Red
+            Write-Host "[FAIL] Type checking failed" -ForegroundColor Red
             exit 1
           }
 
@@ -419,16 +419,16 @@ jobs:
           
           $testScript = "scripts/build-windows/test-portable.ps1"
           if (-not (Test-Path $testScript)) {
-            Write-Host "✗ Test script not found: $testScript" -ForegroundColor Red
+            Write-Host "[FAIL] Test script not found: $testScript" -ForegroundColor Red
             exit 1
           }
           
           # Test help parameter
           try {
             $helpOutput = & $testScript -? 2>&1
-            Write-Host "✓ Test script help output works" -ForegroundColor Green
+            Write-Host "[OK] Test script help output works" -ForegroundColor Green
           } catch {
-            Write-Host "✗ Test script help failed: $_" -ForegroundColor Red
+            Write-Host "[FAIL] Test script help failed: $_" -ForegroundColor Red
             exit 1
           }
           
@@ -446,9 +446,9 @@ jobs:
           # Test with dummy package (should fail gracefully)
           try {
             $result = & $testScript -PackagePath "$testDir/$testPackage" -Quick -Timeout 5 2>&1
-            Write-Host "✓ Test script handles dummy package gracefully" -ForegroundColor Green
+            Write-Host "[OK] Test script handles dummy package gracefully" -ForegroundColor Green
           } catch {
-            Write-Host "✓ Test script properly rejects invalid package (expected behavior)" -ForegroundColor Green
+            Write-Host "[OK] Test script properly rejects invalid package (expected behavior)" -ForegroundColor Green
           }
           
           # Cleanup

--- a/.github/workflows/windows-portable.yml
+++ b/.github/workflows/windows-portable.yml
@@ -1,4 +1,4 @@
-name: Build Windows Portable Serena (Optimized)
+name: Build Windows Portable
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Adds a simplified Windows portable build workflow that:
- Builds portable Windows executables with PyInstaller
- Supports multiple bundle tiers (minimal, essential, complete, full)
- Supports both x64 and ARM64 architectures
- Downloads and bundles language servers
- Creates distribution packages with installer scripts

## Why simplified version?

The previous optimized workflow might be too complex for GitHub Actions to properly index. This simplified version:
- Has cleaner structure
- Focuses on core functionality
- Should be immediately visible in Actions tab
- Easier to debug and maintain

## Testing

After merge, the workflow will be available at:
Actions → Build Windows Portable → Run workflow

Select bundle tier and architecture, then run.