### PR TITLE
Add GitHub Actions workflow for building Windows standalone portable executable

### DIFF
--- a/.github/workflows/test-windows-portable.yml
+++ b/.github/workflows/test-windows-portable.yml
@@ -25,6 +25,7 @@ on:
         options:
           - 'quick'
           - 'full'
+          - 'build'
 
 env:
   PYTHON_VERSION: "3.11"
@@ -542,3 +543,106 @@ jobs:
             echo "⚠️ **Overall Status**: SOME TESTS FAILED" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
+
+  # Actual build job - runs only when manually triggered with build option
+  build-standalone:
+    name: Build Windows Standalone
+    runs-on: windows-latest
+    timeout-minutes: 60
+    # Only run when manually triggered and test_level is 'build'
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.test_level == 'build'
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          architecture: x64
+
+      - name: Install UV package manager
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .venv
+            ~/.cache/uv
+          key: uv-${{ runner.os }}-x64-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+          restore-keys: |
+            uv-${{ runner.os }}-x64-
+            uv-${{ runner.os }}-
+
+      - name: Install dependencies
+        shell: powershell
+        run: |
+          Write-Host "Installing project dependencies..." -ForegroundColor Green
+          uv sync --dev
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "[FAIL] Failed to install dependencies" -ForegroundColor Red
+            exit 1
+          }
+          Write-Host "[OK] Dependencies installed" -ForegroundColor Green
+
+      - name: Install PyInstaller
+        shell: powershell
+        run: |
+          Write-Host "Installing PyInstaller..." -ForegroundColor Green
+          uv add --dev pyinstaller
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "[FAIL] Failed to install PyInstaller" -ForegroundColor Red
+            exit 1
+          }
+          Write-Host "[OK] PyInstaller installed" -ForegroundColor Green
+
+      - name: Download essential language servers
+        shell: powershell
+        run: |
+          Write-Host "Downloading essential language servers..." -ForegroundColor Green
+          & "scripts/build-windows/download-language-servers.ps1" -Tier essential -Architecture x64 -OutputDir "build/language_servers"
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "[WARN] Language server download had issues" -ForegroundColor Yellow
+          } else {
+            Write-Host "[OK] Language servers downloaded" -ForegroundColor Green
+          }
+
+      - name: Build portable executable
+        shell: powershell
+        run: |
+          Write-Host "Building Serena portable executable..." -ForegroundColor Green
+          & "scripts/build-windows/build-portable.ps1" -Tier essential -Architecture x64 -OutputDir "dist"
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "[FAIL] Build failed" -ForegroundColor Red
+            exit 1
+          }
+          Write-Host "[OK] Build completed successfully" -ForegroundColor Green
+
+      - name: List build artifacts
+        shell: powershell
+        run: |
+          Write-Host "Build artifacts:" -ForegroundColor Green
+          if (Test-Path "dist") {
+            Get-ChildItem -Path "dist" -Recurse | ForEach-Object {
+              Write-Host "  $($_.FullName)" -ForegroundColor Cyan
+            }
+          } else {
+            Write-Host "No dist directory found" -ForegroundColor Red
+          }
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: serena-windows-standalone-essential-x64
+          path: |
+            dist/
+            !dist/**/*.pdb
+          retention-days: 30
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- Introduces a new GitHub Actions workflow job to build a Windows standalone portable executable for Serena
- The build job is manually triggered via workflow_dispatch with a `test_level` input set to `build`
- Supports Python 3.11 and x64 architecture

## Changes

### CI/CD Workflow
- Added `build` option to the existing test-level inputs in `.github/workflows/test-windows-portable.yml`
- Created a new job `build-standalone` that:
  - Runs on `windows-latest` with a 60-minute timeout
  - Checks out the repository with full history
  - Sets up Python 3.11 environment
  - Installs UV package manager and caches dependencies
  - Installs project dependencies and PyInstaller using UV
  - Downloads essential language servers required for the build
  - Executes a PowerShell script to build the portable executable
  - Lists the build artifacts in the workflow logs
  - Uploads the build artifacts as a GitHub Actions artifact with a 30-day retention

## Test plan
- [x] Manually trigger the workflow with `test_level: build` and verify the build completes successfully
- [x] Confirm that the build artifacts are uploaded and accessible
- [x] Check logs for successful installation of dependencies, PyInstaller, and language servers
- [x] Validate that the build script exits with appropriate status codes on failure or success

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/87e0d148-cb71-463d-8845-b0c2c67d29ca